### PR TITLE
Better error printing

### DIFF
--- a/abci.go
+++ b/abci.go
@@ -97,7 +97,8 @@ func DeliverTxError(err error) abci.ResponseDeliverTx {
 	tm := errors.Wrap(err)
 	return abci.ResponseDeliverTx{
 		Code: tm.ABCICode(),
-		Log:  fmt.Sprintf("%+v", tm),
+		// TODO: reduce debugging info like with Check?
+		Log: fmt.Sprintf("%+v", tm),
 		// Log:  tm.ABCILog(),
 	}
 }
@@ -109,7 +110,8 @@ func CheckTxError(err error) abci.ResponseCheckTx {
 	tm := errors.Wrap(err)
 	return abci.ResponseCheckTx{
 		Code: tm.ABCICode(),
-		Log:  fmt.Sprintf("%+v", tm),
+		// just minimal trace here, don't spam with full stack
+		Log: fmt.Sprintf("%v", tm),
 		// Log:  tm.ABCILog(),
 	}
 }

--- a/abci_test.go
+++ b/abci_test.go
@@ -2,7 +2,6 @@ package weave_test
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	pkerr "github.com/pkg/errors"
@@ -13,8 +12,6 @@ import (
 )
 
 func TestCreateErrorResult(t *testing.T) {
-	assert := assert.New(t)
-
 	cases := []struct {
 		err  error
 		msg  string
@@ -32,20 +29,20 @@ func TestCreateErrorResult(t *testing.T) {
 		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
 
 			dres := weave.DeliverTxError(tc.err)
-			assert.True(dres.IsErr())
+			assert.True(t, dres.IsErr())
 			// This is if we want minimal logs in the future....
 			// assert.Equal(tc.msg, dres.Log)
-			assert.True(strings.HasPrefix(dres.Log, tc.msg))
-			assert.Contains(dres.Log, "github.com/confio/weave")
-			assert.Equal(tc.code, dres.Code)
+			assert.Contains(t, dres.Log, tc.msg)
+			assert.Contains(t, dres.Log, "confio/weave/abci")
+			assert.Equal(t, tc.code, dres.Code)
 
 			cres := weave.CheckTxError(tc.err)
-			assert.True(cres.IsErr())
+			assert.True(t, cres.IsErr())
 			// This is if we want minimal logs in the future....
 			// assert.Equal(tc.msg, cres.Log)
-			assert.True(strings.HasPrefix(cres.Log, tc.msg))
-			assert.Contains(cres.Log, "github.com/confio/weave")
-			assert.Equal(tc.code, cres.Code)
+			assert.Contains(t, cres.Log, tc.msg)
+			assert.Contains(t, cres.Log, "confio/weave/abci")
+			assert.Equal(t, tc.code, cres.Code)
 		})
 	}
 }

--- a/errors/common.go
+++ b/errors/common.go
@@ -49,7 +49,7 @@ func NormalizePanic(p interface{}) error {
 	if err, isErr := p.(error); isErr {
 		return Wrap(err)
 	}
-	msg := fmt.Sprintf("%v", p)
+	msg := fmt.Sprintf("panic: %v", p)
 	return ErrInternal(msg)
 }
 

--- a/errors/common_test.go
+++ b/errors/common_test.go
@@ -80,15 +80,26 @@ func TestLog(t *testing.T) {
 	}
 
 	for i, tc := range cases {
-		assert.True(t, tc.check(tc.err), "%d", i)
-		// make sure we have a nice error message with code
-		msg := fmt.Sprintf("%s", tc.err)
-		assert.Equal(t, tc.log, msg, "%d", i)
-		// make sure we also get stack dumps....
-		stack := fmt.Sprintf("%+v", tc.err)
-		withCode := "github.com/confio/weave/errors.WithCode\n"
-		thisTest := "github.com/confio/weave/errors.TestLog\n"
-		assert.True(t, strings.Contains(stack, withCode), "%d", i)
-		assert.True(t, strings.Contains(stack, thisTest), "%d", i)
+		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
+
+			assert.True(t, tc.check(tc.err))
+
+			// make sure we have a nice error message with code
+			msg := fmt.Sprintf("%s", tc.err)
+			assert.Equal(t, tc.log, msg)
+
+			// make sure we have a nice error message with code
+			middle := fmt.Sprintf("%v", tc.err)
+			assert.Contains(t, middle, tc.log)
+			assert.Contains(t, middle, "common_test.go")
+
+			// make sure we also get stack dumps....
+			stack := fmt.Sprintf("%+v", tc.err)
+			// we should trim off unneeded stuff
+			withCode := "github.com/confio/weave/errors.WithCode\n"
+			thisTest := "github.com/confio/weave/errors.TestLog\n"
+			assert.False(t, strings.Contains(stack, withCode))
+			assert.True(t, strings.Contains(stack, thisTest))
+		})
 	}
 }

--- a/errors/main.go
+++ b/errors/main.go
@@ -98,7 +98,7 @@ func (t tmerror) Stacktrace() errors.StackTrace {
 	st := t.stackTracer.StackTrace()
 	// trim our internal parts here
 	// manual error creation, or runtime for caught panics
-	for matchesFile(st[0], "/confio/weave/errors/", "/runtime/") {
+	for matchesFile(st[0], "weave/errors/common.go", "weave/errors/main.go", "/runtime/") {
 		st = st[1:]
 	}
 	// trim out outer wrappers (runtime)

--- a/examples/errors/demo.go
+++ b/examples/errors/demo.go
@@ -1,0 +1,47 @@
+/*
+package main demonstrates how we can print out our TMErrors
+
+meant for `go run .../demo.go`
+*/
+package main
+
+import (
+	"fmt"
+
+	"github.com/confio/weave/errors"
+)
+
+func makeError() error {
+	return errors.ErrInternal("foo")
+}
+
+func otherError() error {
+	return errors.ErrDecoding()
+}
+
+type foo struct {
+	a int
+}
+
+func fullError() error {
+	return errors.ErrUnknownTxType(&foo{7})
+}
+
+func panicError() (err error) {
+	defer errors.Recover(&err)
+	panic("uh oh")
+}
+
+func show(err error) {
+	fmt.Printf("Simple: %s\n", err)
+	fmt.Printf("Verbose: %v\n", err)
+	fmt.Printf("Full: %+v\n", err)
+	fmt.Println("\n****")
+}
+
+func main() {
+	show(makeError())
+	show(otherError())
+	show(fullError())
+	show(panicError())
+}


### PR DESCRIPTION
Resolves #35 

Nicer stack traces for "%+v" and minimal debug info for "%v".
Also add a main file to demo.

`go run ./examples/errors/demo.go`