### PR TITLE
Support/buildfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ deps: glide
 	for ex in $(EXAMPLES); do cd $$ex && make deps; done
 
 glide:
-	@go get github.com/tendermint/glide
+	@go get github.com/Masterminds/glide
 
 protoc:
 	protoc --gogofaster_out=. app/*.proto

--- a/examples/mycoind/Makefile
+++ b/examples/mycoind/Makefile
@@ -23,7 +23,7 @@ deps: $(TENDERMINT)
 $(TENDERMINT):
 	@ #install tendermint binary for testing
 	go get github.com/golang/dep/cmd/dep
-	go get -d github.com/tendermint/tendermint || true
+	go get -d github.com/tendermint/tendermint/...
 	cd $$GOPATH/src/github.com/tendermint/tendermint && \
 		git checkout $(TM_VERSION) && \
 		make ensure_deps && make install && \


### PR DESCRIPTION
* use official glide version
* fixes an issue with `make install` (on my box):
`can't load package: package github.com/tendermint/tendermint: no Go files in /foobar/go/src/github.com/tendermint/tendermint`
