### PR TITLE
Introduced verbose feedback on Init in case the app

### DIFF
--- a/commands/server/init.go
+++ b/commands/server/init.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/tendermint/tmlibs/log"
@@ -17,9 +18,11 @@ import (
 const (
 	// AppStateKey is the key in the json json where all info
 	// on initializing the app can be found
-	AppStateKey   = "app_state"
-	flagIndexAll  = "all"
-	flagIndexTags = "tags"
+	AppStateKey    = "app_state"
+	GenesisTimeKey = "genesis_time"
+	flagIndexAll   = "all"
+	flagIndexTags  = "tags"
+	flagForce      = "f"
 )
 
 /*
@@ -28,13 +31,14 @@ Usage:
   xxx init -all=f  // no index
   xxx init -tags=foo,bar // index only foo and bar
 */
-func parseIndex(args []string) (bool, string, []string, error) {
+func parseIndex(args []string) (bool, bool, string, []string, error) {
 	// parse flagIndexAll, flagIndexTags and return the result
 	indexFlags := flag.NewFlagSet("init", flag.ExitOnError)
 	tags := indexFlags.String(flagIndexTags, "", "comma-separated list of tags to index")
 	all := indexFlags.Bool(flagIndexAll, true, "")
+	force := indexFlags.Bool(flagForce, false, "")
 	err := indexFlags.Parse(args)
-	return *all, *tags, indexFlags.Args(), err
+	return *all, *force, *tags, indexFlags.Args(), err
 }
 
 // InitCmd will initialize all files for tendermint,
@@ -46,11 +50,11 @@ func InitCmd(gen GenOptions, logger log.Logger, home string, args []string) erro
 	genFile := filepath.Join(home, "config", "genesis.json")
 	confFile := filepath.Join(home, "config", "config.toml")
 
-	all, tags, args, err := parseIndex(args)
+	all, force, tags, args, err := parseIndex(args)
 	if err != nil {
 		return err
 	}
-	err = setTxIndex(confFile, all, tags)
+	err = setTxIndex(confFile, all, tags, force)
 	if err != nil {
 		return err
 	}
@@ -67,7 +71,12 @@ func InitCmd(gen GenOptions, logger log.Logger, home string, args []string) erro
 	}
 
 	// And add them to the genesis file
-	return addGenesisOptions(genFile, options)
+	err = addGenesisOptions(genFile, options, force)
+	if err == nil {
+		fmt.Println("The application has been succesfully initialised.")
+	}
+
+	return err
 }
 
 // GenOptions can parse command-line and flag to
@@ -80,7 +89,7 @@ type GenOptions func(args []string) (json.RawMessage, error)
 // so we can add one line.
 type GenesisDoc map[string]json.RawMessage
 
-func addGenesisOptions(filename string, options json.RawMessage) error {
+func addGenesisOptions(filename string, options json.RawMessage, force bool) error {
 	bz, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return err
@@ -92,7 +101,16 @@ func addGenesisOptions(filename string, options json.RawMessage) error {
 		return err
 	}
 
+	v, ok := doc[AppStateKey]
+	if !force && ok && len(v) > 0 {
+		return fmt.Errorf("the application has already been initialised, use %s flag to override", flagForce)
+	}
+
+	timeJson, _ := time.Now().MarshalJSON()
+
 	doc[AppStateKey] = options
+	doc[GenesisTimeKey] = timeJson
+
 	out, err := json.MarshalIndent(doc, "", "  ")
 	if err != nil {
 		return err
@@ -113,7 +131,12 @@ var (
 //   indexer = "kv"
 //   index_all_tags = <all>
 //   index_tags = <tags>
-func setTxIndex(config string, all bool, tags string) error {
+func setTxIndex(config string, all bool, tags string, force bool) error {
+	_, err := os.Stat(config)
+	if !force && os.IsExist(err) {
+		return fmt.Errorf("config already exists, use %s flag to override", flagForce)
+	}
+
 	f, err := os.Open(config)
 	if err != nil {
 		return errors.WithStack(err)


### PR DESCRIPTION
was already initialised effectively preventing
a user to do that.
Genesis time is now being updated to init time.
Force flag has been introduced to override re-init
protection.
A message is now being printed if the init was a success.


This still needs tests to be updated.