### PR TITLE
Use sha512 prehash on signbytes in x/sigs

### DIFF
--- a/version.go
+++ b/version.go
@@ -4,7 +4,7 @@ package weave
 const Maj = 0
 
 // Min is the minor version number (updated on minor releases)
-const Min = 5
+const Min = 6
 
 // Fix is the patch number (updated on bugfix releases)
 const Fix = 0


### PR DESCRIPTION
We need this so we can sign with the ledger (it requires sha256 or sha512 or blake2b prehash before signing).

It shouldn't break anything except the js clients (which Simon updated already), as your go clients, should also use `BuildSignBytes` directly or indirectly before signing.

I would like to get this in a (breaking) bov release by the next testnet, so we can release the updated js libs with it.